### PR TITLE
Add Python method to get query pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Uber Technologies Inc."]
 name = "piranha"
 description = "Polyglot Piranha is a library for performing structural find and replace with deep cleanup."
-version = "0.3.28"
+version = "0.3.29"
 edition = "2021"
 include = ["pyproject.toml", "src/"]
 exclude = ["legacy"]

--- a/src/models/capture_group_patterns.rs
+++ b/src/models/capture_group_patterns.rs
@@ -45,13 +45,14 @@ pub struct CGPattern(pub String);
 
 #[pymethods]
 impl CGPattern {
-  pub(crate) fn new(query: String) -> Self {
-    Self(query)
-  }
-
-  #[getter]
   pub(crate) fn pattern(&self) -> String {
     self.0.to_string()
+  }
+}
+
+impl CGPattern {
+  pub(crate) fn new(query: String) -> Self {
+    Self(query)
   }
 
   pub(crate) fn extract_regex(&self) -> Result<Regex, regex::Error> {

--- a/src/models/capture_group_patterns.rs
+++ b/src/models/capture_group_patterns.rs
@@ -20,7 +20,7 @@ use crate::{
     Instantiate,
   },
 };
-use pyo3::prelude::pyclass;
+use pyo3::prelude::{pyclass, pymethods};
 use regex::Regex;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
@@ -43,11 +43,13 @@ pub enum PatternType {
 #[derive(Deserialize, Debug, Clone, Default, PartialEq, Hash, Eq)]
 pub struct CGPattern(pub String);
 
+#[pymethods]
 impl CGPattern {
   pub(crate) fn new(query: String) -> Self {
     Self(query)
   }
 
+  #[getter]
   pub(crate) fn pattern(&self) -> String {
     self.0.to_string()
   }


### PR DESCRIPTION
Prior to this change, the `CGPattern` object had no public members exposed in Python. After this change, it has one public method `pattern()` that returns the original query text as a string.